### PR TITLE
A few changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The gist of the mode is to be able to precisely control media playback
 while in a buffer containing that media's transcription. The main use
-case is to rewind the video by a few second in order to re-listen to a
+case is to rewind the video by a few seconds in order to re-listen to a
 few words so they can be typed into the buffer, or corrected. It uses
 VideoLAN's console interface to drive playback from within Emacs.
 

--- a/transcription-mode.el
+++ b/transcription-mode.el
@@ -75,12 +75,6 @@
       (princ "\n")
       (process-send-region transcription-process (point-min) (point-max)))))
 
-(defun transcription-partial (&rest commands)
-  "Return an interactive function applying COMMANDS."
-  (lambda ()
-    (interactive)
-    (apply #'transcription commands)))
-
 (defun transcription-play/pause ()
   "Toggle play/pause on the transcription media."
   (interactive)
@@ -92,32 +86,39 @@
       (transcription :pause)
       (setf (process-get transcription-process :play-state) 'paused))))
 
-(defalias 'transcription-forward-10m
-  (transcription-partial :seek "+600"))
+(defmacro transcription-defun (name &rest commands)
+  "Define an interactive function NAME to run COMMANDS."
+  (declare (indent 1))
+  `(defun ,name ()
+     (interactive)
+     (transcription ,@commands)))
 
-(defalias 'transcription-backward-10m
-  (transcription-partial :seek "-600"))
+(transcription-defun transcription-forward-10m
+  :seek "+600")
 
-(defalias 'transcription-forward-1m
-  (transcription-partial :seek "+60"))
+(transcription-defun transcription-backward-10m
+  :seek "-600")
 
-(defalias 'transcription-backward-1m
-  (transcription-partial :seek "-60"))
+(transcription-defun transcription-forward-1m
+  :seek "+60")
 
-(defalias 'transcription-forward-10s
-  (transcription-partial :seek "+10"))
+(transcription-defun transcription-backward-1m
+  :seek "-60")
 
-(defalias 'transcription-backward-10s
-  (transcription-partial :seek "-10"))
+(transcription-defun transcription-forward-10s
+  :seek "+10")
 
-(defalias 'transcription-forward-3s
-  (transcription-partial :seek "+3"))
+(transcription-defun transcription-backward-10s
+  :seek "-10")
 
-(defalias 'transcription-backward-3s
-  (transcription-partial :seek "-3"))
+(transcription-defun transcription-forward-3s
+  :seek "+3")
 
-(defalias 'transcription-get-time
-  (transcription-partial :get_time))
+(transcription-defun transcription-backward-3s
+  :seek "-3")
+
+(transcription-defun transcription-get-time
+  :get_time)
 
 (defun transcription-seek (time)
   (interactive "nSeek seconds: ")

--- a/transcription-mode.el
+++ b/transcription-mode.el
@@ -37,6 +37,11 @@
     (setf (process-get transcription-process :media-file) file)
     (transcription-play/pause)))
 
+(defun transcription-stop ()
+  "Stop the transcription process."
+  (interactive)
+  (kill-process transcription-process))
+
 (defun transcription-time-filter (_ output)
   (let ((time (string-to-number
                (car (split-string output (char-to-string ?\r))))))


### PR DESCRIPTION
Three changes, listed in order of increasing opinionatedness:

1. Typo fix in readme
2. New command `transcription-stop` (not added to keymap)
3. New macro `transcription-defun` to replace `transcription-partial` / `defalias`

The last item is strictly a rewrite, and it doesn't change any behavior. It even compiles down to the same thing. I think it makes the code clearer, but feel free to reject it.