### PR TITLE
Specify customization type to suppress compilation warning

### DIFF
--- a/transcription-mode.el
+++ b/transcription-mode.el
@@ -17,6 +17,7 @@
 
 (defcustom transcription-vlc-program-name "vlc"
   "Path to the VideoLAN executable"
+  :type '(file :must-match t)
   :group 'transcription-mode)
 
 (defvar transcription-process nil


### PR DESCRIPTION

This fixes the compilation warning that I noticed when I switched to native compilation in emacs 28.
```
Warning (comp): transcription-mode.el:18:1: Warning: defcustom for ‘transcription-vlc-program-name’ fails to specify type
```

I picked the type that seemed best from [this list](https://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Types.html). I chose to require a match to an existing file `(file :must-match t)` because users likely already have VLC installed.

Thanks for the useful package!